### PR TITLE
👔 Fix: 유저 조회 응답 변경

### DIFF
--- a/src/main/java/com/ureca/compliment/user/controller/UserController.java
+++ b/src/main/java/com/ureca/compliment/user/controller/UserController.java
@@ -34,7 +34,13 @@ public class UserController {
     public ResponseEntity<?> getUser(
             @PathVariable("userId") String id
     ) throws UserNotFoundException, SQLException {
-        return ResponseEntity.ok().body(userService.getUser(id));
+        Map<String, Object> data = userService.getUser(id);
+        ResponseWrapper<Map<String, Object>> response = new ResponseWrapper<>(
+                String.valueOf(HttpStatus.OK.value()),  // Status code as a string
+                HttpStatus.OK.getReasonPhrase(),  // "OK"
+                data  // Data from userService
+        );
+        return ResponseEntity.ok().body(response);
     }
 
     @PostMapping("/login")

--- a/src/main/java/com/ureca/compliment/user/service/UserService.java
+++ b/src/main/java/com/ureca/compliment/user/service/UserService.java
@@ -12,6 +12,6 @@ import java.util.Optional;
 public interface UserService {
     Map<String, Object> logIn(String id, String password) throws SQLException;
     Map<String, Object> getAllUsers() throws SQLException;
-    Optional<User> getUser(String id) throws SQLException, UserNotFoundException;
+    Map<String, Object> getUser(String id) throws SQLException, UserNotFoundException;
     List<Compliment> getCompliments(String id) throws SQLException;
 }

--- a/src/main/java/com/ureca/compliment/user/service/UserServiceImpl.java
+++ b/src/main/java/com/ureca/compliment/user/service/UserServiceImpl.java
@@ -45,14 +45,11 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public Optional<User> getUser(String id) throws SQLException, UserNotFoundException {
-        try {
+    public Map<String, Object> getUser(String id) throws SQLException, UserNotFoundException {
             User user = dao.selectUserById(id);
-            return Optional.of(user);
-        } catch (UserNotFoundException e) {
-            return Optional.empty();
-        }
-
+            Map<String, Object> response = new java.util.HashMap<>();
+            response.put("name", user.getName());
+            return response;
     }
 
     @Override


### PR DESCRIPTION
유저 조회에 대한 엔드포인트 응답을 변경합니다.

기존에는 유저에대한 모든 정보를 리턴했지만, 현재 필요한 유저이름만 리턴하도록 변경했습니다.
추가로 응답형식 또한 다른 엔드포인트와 같게 변경했습니다. 