### PR TITLE
Feat: 칭찬 조회 구현

### DIFF
--- a/src/main/java/com/ureca/compliment/compliment/Compliment.java
+++ b/src/main/java/com/ureca/compliment/compliment/Compliment.java
@@ -1,6 +1,6 @@
 package com.ureca.compliment.compliment;
 
-import java.time.LocalDateTime;
+import java.util.Date;
 
 public class Compliment {
     private String id;
@@ -8,8 +8,7 @@ public class Compliment {
     private String receiverId;
     private String content;
     private boolean isAnonymous;
-    private LocalDateTime createdAt;
-    private String date;
+    private Date createdAt;
 
     public Compliment(String id, String senderId, String receiverId, String content, boolean isAnonymous) {
         this.id = id;
@@ -59,19 +58,11 @@ public class Compliment {
         isAnonymous = anonymous;
     }
 
-    public LocalDateTime getCreatedAt() {
+    public Date getCreatedAt() {
         return createdAt;
     }
 
-    public void setCreatedAt(LocalDateTime createdAt) {
+    public void setCreatedAt(Date createdAt) {
         this.createdAt = createdAt;
-    }
-
-    public String getDate() {
-        return date;
-    }
-
-    public void setDate(String date) {
-        this.date = date;
     }
 }

--- a/src/main/java/com/ureca/compliment/compliment/controller/ComplimentController.java
+++ b/src/main/java/com/ureca/compliment/compliment/controller/ComplimentController.java
@@ -5,12 +5,14 @@ import com.ureca.compliment.compliment.exceptions.ComplimentAlreadyExistsExcepti
 import com.ureca.compliment.compliment.service.ComplimentService;
 import com.ureca.compliment.util.response.ResponseWrapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import java.sql.SQLException;
+import java.util.Date;
 import java.util.Map;
 
 @Controller
@@ -43,9 +45,11 @@ public class ComplimentController {
     }
 
     @GetMapping("")
-    public ResponseEntity<?> senderList(@RequestParam("senderId") String senderId,
-                                      @RequestParam("date") String date) throws SQLException{
-        Map<String, Object> data = service.senderList(senderId, date);
+    public ResponseEntity<?> senderList(
+            @RequestParam(required = false) String senderId,
+            @RequestParam(required = false) @DateTimeFormat(pattern="yyyy-MM-dd") Date date
+    ) throws SQLException{
+        Map<String, Object> data = service.getCompliments(senderId, date);
         ResponseWrapper<Map<String, Object>> response = new ResponseWrapper<>(
                 String.valueOf(HttpStatus.OK.value()),  // Status code as a string
                 HttpStatus.OK.getReasonPhrase(),  // "OK"

--- a/src/main/java/com/ureca/compliment/compliment/controller/ComplimentController.java
+++ b/src/main/java/com/ureca/compliment/compliment/controller/ComplimentController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.sql.SQLException;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 
 @Controller
@@ -45,12 +46,12 @@ public class ComplimentController {
     }
 
     @GetMapping("")
-    public ResponseEntity<?> senderList(
+    public ResponseEntity<?> list(
             @RequestParam(required = false) String senderId,
             @RequestParam(required = false) @DateTimeFormat(pattern="yyyy-MM-dd") Date date
     ) throws SQLException{
-        Map<String, Object> data = service.getCompliments(senderId, date);
-        ResponseWrapper<Map<String, Object>> response = new ResponseWrapper<>(
+        Map<String, List<Compliment>> data = service.getCompliments(senderId, date);
+        ResponseWrapper<Map<String, List<Compliment>>> response = new ResponseWrapper<>(
                 String.valueOf(HttpStatus.OK.value()),  // Status code as a string
                 HttpStatus.OK.getReasonPhrase(),  // "OK"
                 data

--- a/src/main/java/com/ureca/compliment/compliment/dao/ComplimentDAO.java
+++ b/src/main/java/com/ureca/compliment/compliment/dao/ComplimentDAO.java
@@ -6,7 +6,7 @@ import java.sql.SQLException;
 import java.util.List;
 
 public interface ComplimentDAO {
-    int insertComplimnet(Compliment compliment) throws SQLException;
+    int insertcompliment(Compliment compliment) throws SQLException;
 
     List<Compliment> senderList(String senderId, String date) throws SQLException;
 }

--- a/src/main/java/com/ureca/compliment/compliment/dao/ComplimentDAO.java
+++ b/src/main/java/com/ureca/compliment/compliment/dao/ComplimentDAO.java
@@ -3,10 +3,11 @@ package com.ureca.compliment.compliment.dao;
 import com.ureca.compliment.compliment.Compliment;
 
 import java.sql.SQLException;
+import java.util.Date;
 import java.util.List;
 
 public interface ComplimentDAO {
     int insertCompliment(Compliment compliment) throws SQLException;
 
-    List<Compliment> senderList(String senderId, String date) throws SQLException;
+    List<Compliment> senderList(String senderId, Date date) throws SQLException;
 }

--- a/src/main/java/com/ureca/compliment/compliment/dao/ComplimentDAO.java
+++ b/src/main/java/com/ureca/compliment/compliment/dao/ComplimentDAO.java
@@ -6,7 +6,7 @@ import java.sql.SQLException;
 import java.util.List;
 
 public interface ComplimentDAO {
-    int insertcompliment(Compliment compliment) throws SQLException;
+    int insertCompliment(Compliment compliment) throws SQLException;
 
     List<Compliment> senderList(String senderId, String date) throws SQLException;
 }

--- a/src/main/java/com/ureca/compliment/compliment/dao/ComplimentDAO.java
+++ b/src/main/java/com/ureca/compliment/compliment/dao/ComplimentDAO.java
@@ -9,5 +9,10 @@ import java.util.List;
 public interface ComplimentDAO {
     int insertCompliment(Compliment compliment) throws SQLException;
 
-    List<Compliment> senderList(String senderId, Date date) throws SQLException;
+    List<Compliment> findAll() throws SQLException;
+    List<Compliment> findBySenderIdAndDate(String senderId, Date date) throws SQLException;
+
+    List<Compliment> findBySenderId(String senderId) throws SQLException;
+
+    List<Compliment> findByDate(Date date) throws SQLException;
 }

--- a/src/main/java/com/ureca/compliment/compliment/dao/ComplimentDAOImpl.java
+++ b/src/main/java/com/ureca/compliment/compliment/dao/ComplimentDAOImpl.java
@@ -19,7 +19,7 @@ public class ComplimentDAOImpl implements ComplimentDAO{
     DBUtil dbUtil;
 
     @Override
-    public int insertcompliment(Compliment compliment) throws SQLException {
+    public int insertCompliment(Compliment compliment) throws SQLException {
         Connection connection = dbUtil.getConnection();
         String sql = """
                     INSERT INTO COMPLIMENT(ID, SENDER_ID, RECEIVER_ID, CONTENT, IS_ANONYMOUS) 

--- a/src/main/java/com/ureca/compliment/compliment/dao/ComplimentDAOImpl.java
+++ b/src/main/java/com/ureca/compliment/compliment/dao/ComplimentDAOImpl.java
@@ -47,7 +47,34 @@ public class ComplimentDAOImpl implements ComplimentDAO{
     }
 
     @Override
-    public List<Compliment> senderList(String senderId, Date date) throws SQLException {
+    public List<Compliment> findAll() throws SQLException {
+        Connection connection = dbUtil.getConnection();
+        String sql = "SELECT * FROM COMPLIMENT";
+
+        List<Compliment> compliments = new ArrayList<>();
+        try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+            ResultSet resultSet = preparedStatement.executeQuery();
+
+            while (resultSet.next()) {
+                compliments.add(new Compliment(
+                        resultSet.getString("id"),
+                        resultSet.getString("sender_id"),
+                        resultSet.getString("receiver_id"),
+                        resultSet.getString("content"),
+                        resultSet.getBoolean("is_anonymous")
+                ));
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        } finally {
+            connection.close();
+        }
+
+        return compliments;
+    }
+
+    @Override
+    public List<Compliment> findBySenderIdAndDate(String senderId, Date date) throws SQLException {
         
         Connection connection = dbUtil.getConnection();
         String sql = """
@@ -78,4 +105,61 @@ public class ComplimentDAOImpl implements ComplimentDAO{
         }
         return null;
     }
+
+    @Override
+    public List<Compliment> findBySenderId(String senderId) throws SQLException {
+        Connection connection = dbUtil.getConnection();
+        String sql = "SELECT * FROM COMPLIMENT WHERE SENDER_ID = ?";
+
+        List<Compliment> compliments = new ArrayList<>();
+        try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+            preparedStatement.setString(1, senderId);
+            ResultSet resultSet = preparedStatement.executeQuery();
+
+            while (resultSet.next()) {
+                compliments.add(new Compliment(
+                        resultSet.getString("id"),
+                        resultSet.getString("sender_id"),
+                        resultSet.getString("receiver_id"),
+                        resultSet.getString("content"),
+                        resultSet.getBoolean("is_anonymous")
+                ));
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        } finally {
+            connection.close();
+        }
+
+        return compliments;
+    }
+
+    @Override
+    public List<Compliment> findByDate(Date date) throws SQLException {
+        Connection connection = dbUtil.getConnection();
+        String sql = "SELECT * FROM COMPLIMENT WHERE DATE(CREATED_AT) = ?";
+
+        List<Compliment> compliments = new ArrayList<>();
+        try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+            preparedStatement.setDate(1, new java.sql.Date(date.getTime()));  // java.util.Date -> java.sql.Date 변환
+            ResultSet resultSet = preparedStatement.executeQuery();
+
+            while (resultSet.next()) {
+                compliments.add(new Compliment(
+                        resultSet.getString("id"),
+                        resultSet.getString("sender_id"),
+                        resultSet.getString("receiver_id"),
+                        resultSet.getString("content"),
+                        resultSet.getBoolean("is_anonymous")
+                ));
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        } finally {
+            connection.close();
+        }
+
+        return compliments;
+    }
+
 }

--- a/src/main/java/com/ureca/compliment/compliment/dao/ComplimentDAOImpl.java
+++ b/src/main/java/com/ureca/compliment/compliment/dao/ComplimentDAOImpl.java
@@ -11,6 +11,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 @Repository
@@ -46,7 +47,8 @@ public class ComplimentDAOImpl implements ComplimentDAO{
     }
 
     @Override
-    public List<Compliment> senderList(String senderId, String date) throws SQLException {
+    public List<Compliment> senderList(String senderId, Date date) throws SQLException {
+        
         Connection connection = dbUtil.getConnection();
         String sql = """
             SELECT * FROM COMPLIMENT WHERE SENDER_ID = ?
@@ -55,7 +57,7 @@ public class ComplimentDAOImpl implements ComplimentDAO{
         try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
 
             preparedStatement.setString(1, senderId);
-            preparedStatement.setString(2, date);
+            preparedStatement.setDate(2, new java.sql.Date(date.getTime()));
             ResultSet resultSet =  preparedStatement.executeQuery();
             List<Compliment> compliments = new ArrayList<>();
             while(resultSet.next()){

--- a/src/main/java/com/ureca/compliment/compliment/dao/ComplimentDAOImpl.java
+++ b/src/main/java/com/ureca/compliment/compliment/dao/ComplimentDAOImpl.java
@@ -19,7 +19,7 @@ public class ComplimentDAOImpl implements ComplimentDAO{
     DBUtil dbUtil;
 
     @Override
-    public int insertComplimnet(Compliment compliment) throws SQLException {
+    public int insertcompliment(Compliment compliment) throws SQLException {
         Connection connection = dbUtil.getConnection();
         String sql = """
                     INSERT INTO COMPLIMENT(ID, SENDER_ID, RECEIVER_ID, CONTENT, IS_ANONYMOUS) 

--- a/src/main/java/com/ureca/compliment/compliment/service/ComplimentService.java
+++ b/src/main/java/com/ureca/compliment/compliment/service/ComplimentService.java
@@ -5,9 +5,10 @@ import com.ureca.compliment.compliment.exceptions.ComplimentAlreadyExistsExcepti
 
 import java.sql.SQLException;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 
 public interface ComplimentService {
     Map<String, Integer> create(Compliment compliment) throws SQLException, ComplimentAlreadyExistsException;
-    Map<String, Object> getCompliments(String senderId, Date date) throws SQLException;
+    Map<String, List<Compliment>> getCompliments(String senderId, Date date) throws SQLException;
 }

--- a/src/main/java/com/ureca/compliment/compliment/service/ComplimentService.java
+++ b/src/main/java/com/ureca/compliment/compliment/service/ComplimentService.java
@@ -4,9 +4,10 @@ import com.ureca.compliment.compliment.Compliment;
 import com.ureca.compliment.compliment.exceptions.ComplimentAlreadyExistsException;
 
 import java.sql.SQLException;
+import java.util.Date;
 import java.util.Map;
 
 public interface ComplimentService {
     Map<String, Integer> create(Compliment compliment) throws SQLException, ComplimentAlreadyExistsException;
-    Map<String, Object> senderList(String senderId, String date) throws SQLException;
+    Map<String, Object> getCompliments(String senderId, Date date) throws SQLException;
 }

--- a/src/main/java/com/ureca/compliment/compliment/service/ComplimentServiceImpl.java
+++ b/src/main/java/com/ureca/compliment/compliment/service/ComplimentServiceImpl.java
@@ -4,6 +4,7 @@ import com.ureca.compliment.compliment.Compliment;
 import com.ureca.compliment.compliment.dao.ComplimentDAO;
 import com.ureca.compliment.compliment.exceptions.ComplimentAlreadyExistsException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 
 import java.sql.SQLException;
@@ -16,7 +17,7 @@ public class ComplimentServiceImpl implements ComplimentService{
 
     @Override
     public Map<String, Integer> create(Compliment compliment) throws SQLException, ComplimentAlreadyExistsException {
-        List<Compliment> senderList = dao.senderList(compliment.getSenderId(), compliment.getCreatedAt());
+        List<Compliment> senderList = dao.findBySenderIdAndDate(compliment.getSenderId(), compliment.getCreatedAt());
 
         if (!senderList.isEmpty()) {
             throw new ComplimentAlreadyExistsException("Compliment already exists for this sender on this date");
@@ -32,12 +33,20 @@ public class ComplimentServiceImpl implements ComplimentService{
     }
 
     @Override
-    public Map<String,  Object> getCompliments(String senderId, Date date) throws SQLException {
-        Map<String, Object> response = new HashMap<>();
-        List<Compliment> senderList = dao.senderList(senderId, date);
-        response.put("list", senderList);
-        return response;
-    }
+    public Map<String, List<Compliment>> getCompliments(String senderId, Date date) throws SQLException {
+        List<Compliment> compliments;
 
-    
+        if (senderId != null && date != null) {
+            compliments = dao.findBySenderIdAndDate(senderId, date);
+        } else if (senderId != null) {
+            compliments = dao.findBySenderId(senderId);
+        } else if (date != null) {
+            compliments = dao.findByDate(date);
+        } else {
+            compliments = dao.findAll(); 
+        }
+        Map<String, List<Compliment>> data = new HashMap<>();
+        data.put("compliments", compliments);
+        return data;
+    }
 }

--- a/src/main/java/com/ureca/compliment/compliment/service/ComplimentServiceImpl.java
+++ b/src/main/java/com/ureca/compliment/compliment/service/ComplimentServiceImpl.java
@@ -16,7 +16,7 @@ public class ComplimentServiceImpl implements ComplimentService{
 
     @Override
     public Map<String, Integer> create(Compliment compliment) throws SQLException, ComplimentAlreadyExistsException {
-        List<Compliment> senderList = dao.senderList(compliment.getSenderId(), compliment.getDate());
+        List<Compliment> senderList = dao.senderList(compliment.getSenderId(), compliment.getCreatedAt());
 
         if (!senderList.isEmpty()) {
             throw new ComplimentAlreadyExistsException("Compliment already exists for this sender on this date");
@@ -32,7 +32,7 @@ public class ComplimentServiceImpl implements ComplimentService{
     }
 
     @Override
-    public Map<String,  Object> senderList(String senderId, String date) throws SQLException {
+    public Map<String,  Object> getCompliments(String senderId, Date date) throws SQLException {
         Map<String, Object> response = new HashMap<>();
         List<Compliment> senderList = dao.senderList(senderId, date);
         response.put("list", senderList);

--- a/src/main/java/com/ureca/compliment/compliment/service/ComplimentServiceImpl.java
+++ b/src/main/java/com/ureca/compliment/compliment/service/ComplimentServiceImpl.java
@@ -26,7 +26,7 @@ public class ComplimentServiceImpl implements ComplimentService{
         compliment.setId(UUID.randomUUID().toString());
         
         Map<String, Integer> response = new HashMap<>();
-        int insert = dao.insertComplimnet(compliment);
+        int insert = dao.insertcompliment(compliment);
         response.put("insert", insert);
         return response;
     }

--- a/src/main/java/com/ureca/compliment/compliment/service/ComplimentServiceImpl.java
+++ b/src/main/java/com/ureca/compliment/compliment/service/ComplimentServiceImpl.java
@@ -26,7 +26,7 @@ public class ComplimentServiceImpl implements ComplimentService{
         compliment.setId(UUID.randomUUID().toString());
         
         Map<String, Integer> response = new HashMap<>();
-        int insert = dao.insertcompliment(compliment);
+        int insert = dao.insertCompliment(compliment);
         response.put("insert", insert);
         return response;
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 spring.application.name=compliment
 jwt.secret=f86ae048c185ec881e3898f66576c386c13d261d6646bd793736df6c7141c3d8
 jwt.expiration=3600000
+logging.level.root=DEBUG


### PR DESCRIPTION
# 주요 변경사항
- 기존 `ComplimentService`의 `senderList` 메서드를 `getCompliments` 메서드로 변경하여 `senderId`, `date`가 없어도 조회가 가능하도록 변경. 이제 `senderId`, `date`는 `Option`으로 변경됨
- date 파라미터를 `String` -> `Date` 타입으로 변경