### PR TITLE
✨ Fix: compliment 조회 응답형식 변경

### DIFF
--- a/src/main/java/com/ureca/compliment/compliment/controller/ComplimentController.java
+++ b/src/main/java/com/ureca/compliment/compliment/controller/ComplimentController.java
@@ -1,6 +1,7 @@
 package com.ureca.compliment.compliment.controller;
 
 import com.ureca.compliment.compliment.Compliment;
+import com.ureca.compliment.compliment.dto.ComplimentDTO;
 import com.ureca.compliment.compliment.exceptions.ComplimentAlreadyExistsException;
 import com.ureca.compliment.compliment.service.ComplimentService;
 import com.ureca.compliment.util.response.ResponseWrapper;
@@ -48,10 +49,11 @@ public class ComplimentController {
     @GetMapping("")
     public ResponseEntity<?> list(
             @RequestParam(required = false) String senderId,
-            @RequestParam(required = false) @DateTimeFormat(pattern="yyyy-MM-dd") Date date
+            @RequestParam(required = false) @DateTimeFormat(pattern="yyyy-MM-dd") Date date,
+            @RequestParam(required = false) boolean includeUser
     ) throws SQLException{
-        Map<String, List<Compliment>> data = service.getCompliments(senderId, date);
-        ResponseWrapper<Map<String, List<Compliment>>> response = new ResponseWrapper<>(
+        Map<String, List<ComplimentDTO>> data = service.getCompliments(senderId, date, includeUser);
+        ResponseWrapper<Map<String, List<ComplimentDTO>>> response = new ResponseWrapper<>(
                 String.valueOf(HttpStatus.OK.value()),  // Status code as a string
                 HttpStatus.OK.getReasonPhrase(),  // "OK"
                 data

--- a/src/main/java/com/ureca/compliment/compliment/controller/ComplimentController.java
+++ b/src/main/java/com/ureca/compliment/compliment/controller/ComplimentController.java
@@ -49,10 +49,9 @@ public class ComplimentController {
     @GetMapping("")
     public ResponseEntity<?> list(
             @RequestParam(required = false) String senderId,
-            @RequestParam(required = false) @DateTimeFormat(pattern="yyyy-MM-dd") Date date,
-            @RequestParam(required = false) boolean includeUser
+            @RequestParam(required = false) @DateTimeFormat(pattern="yyyy-MM-dd") Date date
     ) throws SQLException{
-        Map<String, List<ComplimentDTO>> data = service.getCompliments(senderId, date, includeUser);
+        Map<String, List<ComplimentDTO>> data = service.getCompliments(senderId, date);
         ResponseWrapper<Map<String, List<ComplimentDTO>>> response = new ResponseWrapper<>(
                 String.valueOf(HttpStatus.OK.value()),  // Status code as a string
                 HttpStatus.OK.getReasonPhrase(),  // "OK"
@@ -60,5 +59,4 @@ public class ComplimentController {
         );
         return ResponseEntity.ok().body(response);
     }
-
 }

--- a/src/main/java/com/ureca/compliment/compliment/dao/ComplimentDAOImpl.java
+++ b/src/main/java/com/ureca/compliment/compliment/dao/ComplimentDAOImpl.java
@@ -56,13 +56,15 @@ public class ComplimentDAOImpl implements ComplimentDAO{
             ResultSet resultSet = preparedStatement.executeQuery();
 
             while (resultSet.next()) {
-                compliments.add(new Compliment(
+                Compliment compliment = new Compliment(
                         resultSet.getString("id"),
                         resultSet.getString("sender_id"),
                         resultSet.getString("receiver_id"),
                         resultSet.getString("content"),
                         resultSet.getBoolean("is_anonymous")
-                ));
+                );
+                compliment.setCreatedAt(resultSet.getDate("created_at"));
+                compliments.add(compliment);
             }
         } catch (SQLException e) {
             e.printStackTrace();
@@ -88,13 +90,15 @@ public class ComplimentDAOImpl implements ComplimentDAO{
             ResultSet resultSet =  preparedStatement.executeQuery();
             List<Compliment> compliments = new ArrayList<>();
             while(resultSet.next()){
-                compliments.add(new Compliment(
-                    resultSet.getString("id"),
-                    resultSet.getString("sender_id"),
-                    resultSet.getString("receiver_id"),
-                    resultSet.getString("content"),
-                    resultSet.getBoolean("is_anonymous")
-                ));
+                Compliment compliment = new Compliment(
+                        resultSet.getString("id"),
+                        resultSet.getString("sender_id"),
+                        resultSet.getString("receiver_id"),
+                        resultSet.getString("content"),
+                        resultSet.getBoolean("is_anonymous")
+                );
+                compliment.setCreatedAt(resultSet.getDate("created_at"));
+                compliments.add(compliment);
             }
             return compliments;
 
@@ -117,13 +121,15 @@ public class ComplimentDAOImpl implements ComplimentDAO{
             ResultSet resultSet = preparedStatement.executeQuery();
 
             while (resultSet.next()) {
-                compliments.add(new Compliment(
+                Compliment compliment = new Compliment(
                         resultSet.getString("id"),
                         resultSet.getString("sender_id"),
                         resultSet.getString("receiver_id"),
                         resultSet.getString("content"),
                         resultSet.getBoolean("is_anonymous")
-                ));
+                );
+                compliment.setCreatedAt(resultSet.getDate("created_at"));
+                compliments.add(compliment);
             }
         } catch (SQLException e) {
             e.printStackTrace();
@@ -145,13 +151,15 @@ public class ComplimentDAOImpl implements ComplimentDAO{
             ResultSet resultSet = preparedStatement.executeQuery();
 
             while (resultSet.next()) {
-                compliments.add(new Compliment(
+                Compliment compliment = new Compliment(
                         resultSet.getString("id"),
                         resultSet.getString("sender_id"),
                         resultSet.getString("receiver_id"),
                         resultSet.getString("content"),
                         resultSet.getBoolean("is_anonymous")
-                ));
+                );
+                compliment.setCreatedAt(resultSet.getDate("created_at"));
+                compliments.add(compliment);
             }
         } catch (SQLException e) {
             e.printStackTrace();

--- a/src/main/java/com/ureca/compliment/compliment/dto/ComplimentDTO.java
+++ b/src/main/java/com/ureca/compliment/compliment/dto/ComplimentDTO.java
@@ -1,0 +1,93 @@
+package com.ureca.compliment.compliment.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.ureca.compliment.user.dto.UserDTO;
+
+import java.util.Date;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ComplimentDTO {
+    private String id;
+    private String content;
+    private boolean isAnonymous;
+    private Date createAt;
+
+    private String senderId;
+    private String receiverId;
+    private UserDTO sender;
+    private UserDTO receiver;
+
+
+    public ComplimentDTO(String id, String content, boolean isAnonymous, Date createAt) {
+        this.id = id;
+        this.content = content;
+        this.isAnonymous = isAnonymous;
+        this.createAt = createAt;
+    }
+
+    public String getSenderId() {
+        return senderId;
+    }
+
+    public void setSenderId(String senderId) {
+        this.senderId = senderId;
+    }
+
+    public String getReceiverId() {
+        return receiverId;
+    }
+
+    public void setReceiverId(String receiverId) {
+        this.receiverId = receiverId;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public boolean isAnonymous() {
+        return isAnonymous;
+    }
+
+    public void setAnonymous(boolean anonymous) {
+        isAnonymous = anonymous;
+    }
+
+    public Date getCreateAt() {
+        return createAt;
+    }
+
+    public void setCreateAt(Date createAt) {
+        this.createAt = createAt;
+    }
+
+    public UserDTO getSender() {
+        return sender;
+    }
+
+    public void setSender(UserDTO sender) {
+        this.sender = sender;
+    }
+
+    public UserDTO getReceiver() {
+        return receiver;
+    }
+
+    public void setReceiver(UserDTO receiver) {
+        this.receiver = receiver;
+    }
+
+
+}

--- a/src/main/java/com/ureca/compliment/compliment/mapper/ComplimentMapper.java
+++ b/src/main/java/com/ureca/compliment/compliment/mapper/ComplimentMapper.java
@@ -1,0 +1,25 @@
+package com.ureca.compliment.compliment.mapper;
+
+
+import com.ureca.compliment.compliment.Compliment;
+import com.ureca.compliment.compliment.dto.ComplimentDTO;
+import com.ureca.compliment.user.dto.UserDTO;
+
+public class ComplimentMapper {
+     public static ComplimentDTO toDTO(Compliment compliment, UserDTO sender, UserDTO receiver) {
+         ComplimentDTO complimentDTO = new ComplimentDTO(
+                 compliment.getId(),
+                 compliment.getContent(),
+                 compliment.isAnonymous(),
+                 compliment.getCreatedAt()
+         );
+         if (sender == null || receiver == null) {
+             complimentDTO.setSenderId(compliment.getSenderId());
+             complimentDTO.setReceiverId(compliment.getReceiverId());
+         } else {
+             complimentDTO.setSender(sender);
+             complimentDTO.setReceiver(receiver);
+         }
+         return complimentDTO;
+    }
+}

--- a/src/main/java/com/ureca/compliment/compliment/mapper/ComplimentMapper.java
+++ b/src/main/java/com/ureca/compliment/compliment/mapper/ComplimentMapper.java
@@ -13,13 +13,8 @@ public class ComplimentMapper {
                  compliment.isAnonymous(),
                  compliment.getCreatedAt()
          );
-         if (sender == null || receiver == null) {
-             complimentDTO.setSenderId(compliment.getSenderId());
-             complimentDTO.setReceiverId(compliment.getReceiverId());
-         } else {
-             complimentDTO.setSender(sender);
-             complimentDTO.setReceiver(receiver);
-         }
+         complimentDTO.setSender(sender);
+         complimentDTO.setReceiver(receiver);
          return complimentDTO;
     }
 }

--- a/src/main/java/com/ureca/compliment/compliment/service/ComplimentService.java
+++ b/src/main/java/com/ureca/compliment/compliment/service/ComplimentService.java
@@ -11,5 +11,5 @@ import java.util.Map;
 
 public interface ComplimentService {
     Map<String, Integer> create(Compliment compliment) throws SQLException, ComplimentAlreadyExistsException;
-    Map<String, List<ComplimentDTO>> getCompliments(String senderId, Date date, boolean includeUser) throws SQLException;
+    Map<String, List<ComplimentDTO>> getCompliments(String senderId, Date date) throws SQLException;
 }

--- a/src/main/java/com/ureca/compliment/compliment/service/ComplimentService.java
+++ b/src/main/java/com/ureca/compliment/compliment/service/ComplimentService.java
@@ -1,6 +1,7 @@
 package com.ureca.compliment.compliment.service;
 
 import com.ureca.compliment.compliment.Compliment;
+import com.ureca.compliment.compliment.dto.ComplimentDTO;
 import com.ureca.compliment.compliment.exceptions.ComplimentAlreadyExistsException;
 
 import java.sql.SQLException;
@@ -10,5 +11,5 @@ import java.util.Map;
 
 public interface ComplimentService {
     Map<String, Integer> create(Compliment compliment) throws SQLException, ComplimentAlreadyExistsException;
-    Map<String, List<Compliment>> getCompliments(String senderId, Date date) throws SQLException;
+    Map<String, List<ComplimentDTO>> getCompliments(String senderId, Date date, boolean includeUser) throws SQLException;
 }

--- a/src/main/java/com/ureca/compliment/compliment/service/ComplimentServiceImpl.java
+++ b/src/main/java/com/ureca/compliment/compliment/service/ComplimentServiceImpl.java
@@ -41,7 +41,7 @@ public class ComplimentServiceImpl implements ComplimentService{
     }
 
     @Override
-    public Map<String, List<ComplimentDTO>> getCompliments(String senderId, Date date, boolean includeUser) throws SQLException {
+    public Map<String, List<ComplimentDTO>> getCompliments(String senderId, Date date) throws SQLException {
         List<Compliment> compliments;
 
         if (senderId != null && date != null) {
@@ -56,27 +56,18 @@ public class ComplimentServiceImpl implements ComplimentService{
 
         Map<String, List<ComplimentDTO>> result = new HashMap<>();
 
-        if (includeUser) {
-            Set<String> userIds = Stream.concat(
-                    compliments.stream().map(Compliment::getSenderId), // senderId 스트림
-                    compliments.stream().map(Compliment::getReceiverId) // receiverId 스트림
-            ).collect(Collectors.toSet()); // 두 스트림을 합친 후 Set으로 수집
-
-            List<UserDTO> users = userService.getUsersByIds(userIds);
-            Map<String, UserDTO> userMap = users.stream()
-                    .collect(Collectors.toMap(UserDTO::getId, user -> user));
-
-            for (Compliment compliment : compliments) {
-                UserDTO sender = userMap.get(compliment.getSenderId());
-                UserDTO receiver = userMap.get(compliment.getReceiverId());
-                ComplimentDTO complimentDTO = ComplimentMapper.toDTO(compliment, sender, receiver);
-                result.computeIfAbsent("compliments", k -> new ArrayList<>()).add(complimentDTO);
-            }
-        } else {
-            for (Compliment compliment : compliments) {
-                ComplimentDTO complimentDTO = ComplimentMapper.toDTO(compliment, null, null);
-                result.computeIfAbsent("compliments", k -> new ArrayList<>()).add(complimentDTO);
-            }
+        Set<String> userIds = Stream.concat(
+                compliments.stream().map(Compliment::getSenderId), // senderId 스트림
+                compliments.stream().map(Compliment::getReceiverId) // receiverId 스트림
+        ).collect(Collectors.toSet()); // 두 스트림을 합친 후 Set으로 수집
+        List<UserDTO> users = userService.getUsersByIds(userIds);
+        Map<String, UserDTO> userMap = users.stream()
+                .collect(Collectors.toMap(UserDTO::getId, user -> user));
+        for (Compliment compliment : compliments) {
+            UserDTO sender = userMap.get(compliment.getSenderId());
+            UserDTO receiver = userMap.get(compliment.getReceiverId());
+            ComplimentDTO complimentDTO = ComplimentMapper.toDTO(compliment, sender, receiver);
+            result.computeIfAbsent("compliments", k -> new ArrayList<>()).add(complimentDTO);
         }
 
         return result;

--- a/src/main/java/com/ureca/compliment/user/dao/UserDAO.java
+++ b/src/main/java/com/ureca/compliment/user/dao/UserDAO.java
@@ -5,9 +5,11 @@ import com.ureca.compliment.user.exceptions.UserNotFoundException;
 
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Set;
 
 public interface UserDAO {
     User selectUserByIdAndPassword(String id, String password) throws SQLException, UserNotFoundException;
     User selectUserById(String id) throws SQLException, UserNotFoundException;
+    List<User> selectUsersByIds(Set<String> ids) throws SQLException;
     List<User> selectAllUsers() throws SQLException;
 }

--- a/src/main/java/com/ureca/compliment/user/dto/UserDTO.java
+++ b/src/main/java/com/ureca/compliment/user/dto/UserDTO.java
@@ -1,0 +1,28 @@
+package com.ureca.compliment.user.dto;
+
+
+public class UserDTO {
+    private String id;
+    private String name;
+
+    public UserDTO(String id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/ureca/compliment/user/mapper/UserMapper.java
+++ b/src/main/java/com/ureca/compliment/user/mapper/UserMapper.java
@@ -1,0 +1,26 @@
+package com.ureca.compliment.user.mapper;
+
+
+import com.ureca.compliment.user.User;
+import com.ureca.compliment.user.dto.UserDTO;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class UserMapper {
+    public static UserDTO toDTO(User user) {
+        if (user == null) {
+            return null;
+        }
+        return new UserDTO(user.getId(), user.getName());
+    }
+
+    public static List<UserDTO> toDTOList(List<User> users) {
+        if (users == null) {
+            return null;
+        }
+        return users.stream()
+                .map(UserMapper::toDTO)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/ureca/compliment/user/service/UserService.java
+++ b/src/main/java/com/ureca/compliment/user/service/UserService.java
@@ -2,16 +2,19 @@ package com.ureca.compliment.user.service;
 
 import com.ureca.compliment.compliment.Compliment;
 import com.ureca.compliment.user.User;
+import com.ureca.compliment.user.dto.UserDTO;
 import com.ureca.compliment.user.exceptions.UserNotFoundException;
 
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 public interface UserService {
     Map<String, Object> logIn(String id, String password) throws SQLException;
     Map<String, Object> getAllUsers() throws SQLException;
     Map<String, Object> getUser(String id) throws SQLException, UserNotFoundException;
+    List<UserDTO>  getUsersByIds(Set<String> userIds) throws  SQLException;
     List<Compliment> getCompliments(String id) throws SQLException;
 }

--- a/src/main/java/com/ureca/compliment/user/service/UserServiceImpl.java
+++ b/src/main/java/com/ureca/compliment/user/service/UserServiceImpl.java
@@ -3,8 +3,10 @@ package com.ureca.compliment.user.service;
 import com.ureca.compliment.compliment.Compliment;
 import com.ureca.compliment.user.User;
 import com.ureca.compliment.user.dao.UserDAO;
+import com.ureca.compliment.user.dto.UserDTO;
 import com.ureca.compliment.user.exceptions.UserNotFoundException;
 
+import com.ureca.compliment.user.mapper.UserMapper;
 import com.ureca.compliment.util.auth.service.TokenService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -13,6 +15,7 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 @Service
 public class UserServiceImpl implements UserService {
@@ -50,6 +53,16 @@ public class UserServiceImpl implements UserService {
             Map<String, Object> response = new java.util.HashMap<>();
             response.put("name", user.getName());
             return response;
+    }
+
+    @Override
+    public List<UserDTO> getUsersByIds(Set<String> userIds) throws SQLException {
+        try {
+            List<User> users = dao.selectUsersByIds(userIds);
+            return UserMapper.toDTOList(users);
+        } catch (Exception e) {
+            throw new SQLException(e);
+        }
     }
 
     @Override


### PR DESCRIPTION
# 주요 변경사항
- DTO 개념 적용
    - DTO(Data Transfer Object, 데이터 전송 객체)를 적용하여 Compliment와 User정보를 한번에 클라이언트에게 전달했습니다.
    - 기존 Compliment 클래스의 속성에는 sender_id, receiver_id와 같이 id 속성뿐이라 화면에서 사용자의 이름을 보여주기 위해 DTO를 만들어서 id String이 아닌 객체를 넣었습니다. 
- Mapper 클래스도 등장
    - Mapper 클래스는 Entity객체를 DTO객체로 변환합니다. 
- `Compliment` 응답값에 `CreatedAt` 필드 추가
~~- `GET /compliments` 쿼리 파라미터에 `boolean includeUser` 추가~~
   ~~- `includeUser` 유무에 따라 응답에서 user_id를 리턴할수도, user객체를 리턴할수도 있습니다.~~